### PR TITLE
[feature]共通設定を追加

### DIFF
--- a/.dev.vars.sample
+++ b/.dev.vars.sample
@@ -1,0 +1,1 @@
+API_SECRET=""

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # resas-proxy
 
 ## 概要
+
 下記apiにアクセスするためのproxyです。
 https://yumemi-frontend-engineer-codecheck-api.vercel.app/api-doc
 
@@ -12,3 +13,15 @@ https://yumemi-frontend-engineer-codecheck-api.vercel.app/api-doc
 $ pnpm install
 $ pnpm run dev
 ```
+
+## 利用するsecretについて
+
+ローカルで確認する場合、`c.env.XXX`でアクセス可能なsecretについては下記の設定が必要です。
+
+1. `.dev.vars`の作成
+```
+# copy file
+$ cp ./.dev.vars.sample ./.dev.vars
+```
+
+2. `.dev.vars`に必要な値を設定

--- a/src/configs/index.ts
+++ b/src/configs/index.ts
@@ -1,0 +1,11 @@
+/**
+ * [NOTE]
+ * baseUrl, apiごとのendpointは環境によって変更される可能性もあるが、
+ * 今回は固定値として設定します。
+ */
+export const configs = {
+	baseUrl: "https://yumemi-frontend-engineer-codecheck-api.vercel.app",
+	prefectures: {
+		path: "/api/v1/prefectures",
+	},
+} as const;

--- a/src/configs/index.ts
+++ b/src/configs/index.ts
@@ -8,4 +8,7 @@ export const configs = {
 	prefectures: {
 		path: "/api/v1/prefectures",
 	},
+	populationCompositionPerYear: {
+		path: "/api/v1/population/composition/perYear",
+	},
 } as const;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
-import { Hono } from 'hono'
+import { Hono } from "hono";
 
-const app = new Hono()
+const app = new Hono();
 
-app.get('/', (c) => {
-  return c.text('Hello Hono!')
-})
+app.get("/", (c) => {
+	return c.text("Hello Hono!");
+});
 
-export default app
+export default app;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 
-const app = new Hono();
+const app = new Hono<{ Bindings: Bindings }>();
 
 app.get("/", (c) => {
 	return c.text("Hello Hono!");

--- a/src/types/hono.ts
+++ b/src/types/hono.ts
@@ -1,0 +1,3 @@
+type Bindings = {
+	API_SECRET: string;
+};

--- a/src/utils/ApiError.test.ts
+++ b/src/utils/ApiError.test.ts
@@ -1,0 +1,19 @@
+import { ApiError } from "./ApiError";
+
+describe("ApiError", () => {
+	it("status, statusTextが設定される", () => {
+		const error = new ApiError({
+			message: "Error",
+			status: 404,
+			statusText: "Not Found",
+		});
+		expect(error.status).toBe(404);
+		expect(error.statusText).toBe("Not Found");
+	});
+
+	it("status, statusTextがデフォルト値で設定される", () => {
+		const error = new ApiError({ message: "Error" });
+		expect(error.status).toBe(500);
+		expect(error.statusText).toBe("Internal Server Error");
+	});
+});

--- a/src/utils/ApiError.test.ts
+++ b/src/utils/ApiError.test.ts
@@ -4,15 +4,18 @@ describe("ApiError", () => {
 	it("status, statusTextが設定される", () => {
 		const error = new ApiError({
 			message: "Error",
+			name: "SampleError",
 			status: 404,
 			statusText: "Not Found",
 		});
+		expect(error.name).toBe("SampleError");
 		expect(error.status).toBe(404);
 		expect(error.statusText).toBe("Not Found");
 	});
 
-	it("status, statusTextがデフォルト値で設定される", () => {
+	it("name, status, statusTextがデフォルト値で設定される", () => {
 		const error = new ApiError({ message: "Error" });
+		expect(error.name).toBe("ApiError");
 		expect(error.status).toBe(500);
 		expect(error.statusText).toBe("Internal Server Error");
 	});

--- a/src/utils/ApiError.ts
+++ b/src/utils/ApiError.ts
@@ -1,13 +1,16 @@
 export class ApiError extends Error {
+	name: string;
 	status: number;
 	statusText: string;
 
 	constructor({
 		message,
+		name,
 		status,
 		statusText,
-	}: { message: string; status?: number; statusText?: string }) {
+	}: { message: string; name?: string; status?: number; statusText?: string }) {
 		super(message);
+		this.name = name || "ApiError";
 		this.status = status || 500;
 		this.statusText = statusText || "Internal Server Error";
 	}

--- a/src/utils/ApiError.ts
+++ b/src/utils/ApiError.ts
@@ -1,0 +1,14 @@
+export class ApiError extends Error {
+	status: number;
+	statusText: string;
+
+	constructor({
+		message,
+		status,
+		statusText,
+	}: { message: string; status?: number; statusText?: string }) {
+		super(message);
+		this.status = status || 500;
+		this.statusText = statusText || "Internal Server Error";
+	}
+}

--- a/src/utils/HttpClient.test.ts
+++ b/src/utils/HttpClient.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from "vitest";
+import { ApiError } from "./ApiError";
+import { HttpClient } from "./HttpClient";
+
+const mockFetch = vi.fn();
+
+globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+describe("HttpClient", () => {
+	const baseURL = "https://sample-resas-api.com";
+	let client: HttpClient;
+
+	beforeEach(() => {
+		client = new HttpClient({ baseURL });
+		mockFetch.mockClear();
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("getに成功したらレスポンスを返す", async () => {
+		mockFetch.mockResolvedValueOnce(
+			new Response(JSON.stringify({ id: 1, title: "Test" }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			}),
+		);
+
+		const result = await client.get("/get/1");
+		expect(result).toEqual({ id: 1, title: "Test" });
+		expect(mockFetch).toHaveBeenCalledWith(
+			`${baseURL}/get/1`,
+			expect.any(Object),
+		);
+	});
+
+	it("postに成功したらレスポンスを返す", async () => {
+		mockFetch.mockResolvedValueOnce(
+			new Response(JSON.stringify({ success: true }), {
+				status: 201,
+				headers: { "Content-Type": "application/json" },
+			}),
+		);
+
+		const result = await client.post("/posts", { title: "New Post" });
+		expect(result).toEqual({ success: true });
+		expect(mockFetch).toHaveBeenCalledWith(
+			`${baseURL}/posts`,
+			expect.any(Object),
+		);
+	});
+
+	it("リトライ回数を超えてエラーを受け取る場合、エラーをthrowする", async () => {
+		mockFetch.mockResolvedValue(
+			new Response(null, { status: 500, statusText: "Internal Server Error" }),
+		);
+
+		await expect(client.get("/error")).rejects.toThrow(
+			"Http Error. Internal Server Error",
+		);
+	});
+
+	it("リトライが成功した場合、レスポンスを返す", async () => {
+		client = new HttpClient({ baseURL, retries: 1 });
+		mockFetch.mockRejectedValueOnce(new Error("Network Error"));
+		mockFetch.mockResolvedValueOnce(
+			new Response(JSON.stringify({ id: 2, title: "Retried" }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			}),
+		);
+
+		const result = await client.get("/retry");
+		expect(result).toEqual({ id: 2, title: "Retried" });
+		expect(mockFetch).toHaveBeenCalledTimes(2);
+	});
+
+	it("AbortErrorが発生した場合、リトライする", async () => {
+		client = new HttpClient({ baseURL, retries: 1 });
+		// 1回目はAbortErrorを発生させる
+		mockFetch.mockRejectedValueOnce(
+			new ApiError({ message: "Abort Error.", name: "AbortError" }),
+		);
+		// 2回目は成功する
+		mockFetch.mockResolvedValueOnce(
+			new Response(JSON.stringify({ id: 1, title: "Test" }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			}),
+		);
+
+		await client.get("/abort");
+		expect(mockFetch).toHaveBeenCalledTimes(2);
+	});
+});

--- a/src/utils/HttpClient.ts
+++ b/src/utils/HttpClient.ts
@@ -1,0 +1,89 @@
+import { ApiError } from "./ApiError";
+
+type HttpMethod = "GET" | "POST" | "PUT" | "DELETE";
+
+interface HttpClientOptions {
+	baseURL?: string;
+	headers?: HeadersInit;
+	timeout?: number;
+	retries?: number;
+}
+
+const DEFAULT_TIMEOUT = 1000;
+const DEFAULT_RETRIES = 1;
+
+export class HttpClient {
+	private baseURL: string;
+	private headers: HeadersInit;
+	private timeout: number;
+	private retries: number;
+
+	constructor(options?: HttpClientOptions) {
+		this.baseURL = options?.baseURL || "";
+		this.headers = options?.headers || {};
+		this.timeout = options?.timeout || DEFAULT_TIMEOUT;
+		this.retries = options?.retries || DEFAULT_RETRIES;
+	}
+
+	private async request<T>(
+		path: string,
+		method: HttpMethod,
+		body?: unknown,
+		customHeaders?: HeadersInit,
+	): Promise<T> {
+		const requestUrl = `${this.baseURL}${path}`;
+		const headers = {
+			...this.headers,
+			...customHeaders,
+		};
+
+		for (let attempt = 0; attempt <= this.retries; attempt++) {
+			try {
+				const response = await fetch(requestUrl, {
+					method,
+					headers,
+					body: body ? JSON.stringify(body) : undefined,
+					signal: AbortSignal.timeout(this.timeout),
+				});
+
+				if (!response.ok) {
+					throw new ApiError({
+						message: `Http Error. ${response.statusText}`,
+						name: "HttpError",
+						status: response.status,
+						statusText: response.statusText,
+					});
+				}
+
+				return (await response.json()) as T;
+			} catch (err) {
+				if (attempt === this.retries) {
+					throw err;
+				}
+				if (err instanceof Error && err.name === "AbortError") {
+					// タイムアウトの場合リトライ
+					continue;
+				}
+				if (err instanceof ApiError) {
+					// 5xxエラーの場合のみリトライ
+					if (err.status < 500) throw err;
+				}
+			}
+		}
+		throw new ApiError({
+			message: "Unexpected Error.",
+			name: "UnexpectedError",
+		});
+	}
+	async get<T>(url: string, customHeaders?: HeadersInit): Promise<T> {
+		return this.request<T>(url, "GET", undefined, customHeaders);
+	}
+
+	async post<T>(
+		url: string,
+		body: unknown,
+		customHeaders?: HeadersInit,
+	): Promise<T> {
+		return this.request<T>(url, "POST", body, customHeaders);
+	}
+}

--- a/wrangler.json
+++ b/wrangler.json
@@ -3,36 +3,4 @@
   "name": "resas-proxy",
   "main": "src/index.ts",
   "compatibility_date": "2025-02-03"
-  // "compatibility_flags": [
-  //   "nodejs_compat"
-  // ],
-  // "vars": {
-  //   "MY_VAR": "my-variable"
-  // },
-  // "kv_namespaces": [
-  //   {
-  //     "binding": "MY_KV_NAMESPACE",
-  //     "id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-  //   }
-  // ],
-  // "r2_buckets": [
-  //   {
-  //     "binding": "MY_BUCKET",
-  //     "bucket_name": "my-bucket"
-  //   }
-  // ],
-  // "d1_databases": [
-  //   {
-  //     "binding": "MY_DB",
-  //     "database_name": "my-database",
-  //     "database_id": ""
-  //   }
-  // ],
-  // "ai": {
-  //   "binding": "AI"
-  // },
-  // "observability": {
-  //   "enabled": true,
-  //   "head_sampling_rate": 1
-  // }
 }


### PR DESCRIPTION
# 概要
共通の設定を追加しています。

- configを追加
  - 管理するものはコールするapiに対した設定のみです
- AppでAPI_SECRETが取得できるように設定
- カスタムエラークラス (ApiError) を追加
- HttpClientを追加 
  - fetchのラッパー

# 参考資料
https://developers.cloudflare.com/workers/wrangler/configuration/#secrets