### PR TITLE
GET /population/compotion/perYear/:prefCode 実装

### DIFF
--- a/src/domains/population/index.ts
+++ b/src/domains/population/index.ts
@@ -1,0 +1,1 @@
+export * from "./populationCompositionPerYear";

--- a/src/domains/population/populationCompositionPerYear.test.ts
+++ b/src/domains/population/populationCompositionPerYear.test.ts
@@ -1,0 +1,64 @@
+import { ApiError } from "@/utils/ApiError";
+import { HttpClient } from "@/utils/HttpClient";
+import { fetchPopulationCompositionPerYear } from "./populationCompositionPerYear";
+
+describe("fetchPopulationCompositionPerYear", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+  it("リクエストに成功したらレスポンスボディを返す", async () => {
+    const mockApiSecret = "test";
+    const mockPrefCode = 123;
+    const mockResponse = {
+      message: "success",
+      result: {
+        boundaryYear: 2020,
+        data: [
+          {
+            label: "年少人口",
+            data: [
+              {
+                year: 1960,
+                value: 1681479,
+                rate: 33.37,
+              },
+            ],
+          },
+        ],
+      },
+    };
+    vi.spyOn(HttpClient.prototype, "get").mockResolvedValueOnce(mockResponse);
+    const httpClient = new HttpClient({ baseURL: "https://sample.com" });
+
+    const prefectures = await fetchPopulationCompositionPerYear(mockPrefCode, {
+      API_SECRET: mockApiSecret,
+    });
+
+    expect(prefectures).toEqual(mockResponse);
+    expect(httpClient.get).toHaveBeenCalledWith(
+      expect.stringContaining(mockPrefCode.toString()),
+      {
+        "X-API-KEY": mockApiSecret,
+      },
+    );
+  });
+  it("リクエストに失敗したらエラーがthrowされる", async () => {
+    const mockApiSecret = "test";
+    const mockPrefCode = 123;
+    const mockError = new ApiError({ message: "mock Error" });
+    vi.spyOn(HttpClient.prototype, "get").mockRejectedValueOnce(mockError);
+    const httpClient = new HttpClient({ baseURL: "https://sample.com" });
+
+    await expect(() =>
+      fetchPopulationCompositionPerYear(mockPrefCode, {
+        API_SECRET: mockApiSecret,
+      }),
+    ).rejects.toThrowError(mockError);
+    expect(httpClient.get).toHaveBeenCalledWith(
+      expect.stringContaining(mockPrefCode.toString()),
+      {
+        "X-API-KEY": mockApiSecret,
+      },
+    );
+  });
+});

--- a/src/domains/population/populationCompositionPerYear.ts
+++ b/src/domains/population/populationCompositionPerYear.ts
@@ -1,0 +1,32 @@
+import { configs } from "@/configs";
+import { HttpClient } from "@/utils/HttpClient";
+
+interface PopulationCompositionPerYearResponse {
+  message: string;
+  result: {
+    boundaryYear: number;
+    data: {
+      label: string;
+      data: {
+        year: number;
+        value: number;
+        rate: number;
+      }[];
+    }[];
+  };
+}
+
+export const fetchPopulationCompositionPerYear = async (
+  prefCode: number,
+  bindings: Bindings,
+) => {
+  const path = `${configs.populationCompositionPerYear.path}?prefCode=${prefCode}`;
+  const httpClient = new HttpClient({ baseURL: configs.baseUrl });
+  const response = await httpClient.get<PopulationCompositionPerYearResponse>(
+    path,
+    {
+      "X-API-KEY": bindings.API_SECRET,
+    },
+  );
+  return response;
+};

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,5 +1,7 @@
+import { fetchPopulationCompositionPerYear } from "@/domains/population";
 import { fetchPrefectures } from "@/domains/prefectures";
 import { Hono } from "hono";
+import { validator } from "hono/validator";
 
 const routes = new Hono<{ Bindings: Bindings }>();
 
@@ -7,5 +9,23 @@ routes.get("/prefectures", async (c) => {
   const response = await fetchPrefectures(c.env);
   return c.json(response);
 });
+
+routes.get(
+  "/population/compotion/perYear/:prefCode",
+  validator("param", (_, c) => {
+    const prefCode = Number(c.req.param("prefCode"));
+    if (typeof prefCode !== "number" || Number.isNaN(prefCode)) {
+      return c.json({ message: "prefCode must be a number" }, { status: 400 });
+    }
+    return {
+      prefCode,
+    };
+  }),
+  async (c) => {
+    const prefCode = Number(c.req.param("prefCode"));
+    const response = await fetchPopulationCompositionPerYear(prefCode, c.env);
+    return c.json(response);
+  },
+);
 
 export default routes;


### PR DESCRIPTION
# 概要
`GET /population/compotion/perYear/:prefCode`の実装です。

# 参考資料
https://yumemi-frontend-engineer-codecheck-api.vercel.app/api-doc